### PR TITLE
fix(precompute): OOM fix + co-locate garden classifier UI with canvas rendering

### DIFF
--- a/front-back-garden/api.py
+++ b/front-back-garden/api.py
@@ -45,7 +45,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 import uvicorn
@@ -629,6 +629,12 @@ def get_tile_source(source_enum: TileSourceEnum) -> TileSource:
 # =============================================================================
 # API Endpoints
 # =============================================================================
+
+@app.get("/", response_class=FileResponse, include_in_schema=False)
+async def serve_ui():
+    """Serve the garden classifier UI."""
+    return FileResponse(Path(__file__).parent / "index.html")
+
 
 @app.get("/health")
 async def health_check():

--- a/front-back-garden/index.html
+++ b/front-back-garden/index.html
@@ -1,0 +1,1528 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Garden Classifier — Front/Back Garden Detection</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+<style>
+:root {
+  --bg: #0a0f1a;
+  --surface: #111827;
+  --surface-2: #1a2332;
+  --border: #2a3a4e;
+  --accent: #22c55e;
+  --accent-dim: #166534;
+  --accent-back: #3b82f6;
+  --accent-back-dim: #1e40af;
+  --text: #e2e8f0;
+  --text-dim: #94a3b8;
+  --danger: #ef4444;
+  --orange: #f59e0b;
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-body: 'Inter', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+.hero {
+  position: relative;
+  padding: 60px 40px 40px;
+  background: linear-gradient(135deg, #0a2e1a 0%, #0a0f1a 40%, #0f1b3a 100%);
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -20%;
+  width: 60%;
+  height: 200%;
+  background: radial-gradient(ellipse, rgba(34,197,94,0.06) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  top: -50%;
+  right: -20%;
+  width: 60%;
+  height: 200%;
+  background: radial-gradient(ellipse, rgba(59,130,246,0.05) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-size: 42px;
+  font-weight: 700;
+  letter-spacing: -1px;
+  position: relative;
+}
+
+.hero h1 .front { color: var(--accent); }
+.hero h1 .back { color: var(--accent-back); }
+
+.hero .subtitle {
+  font-size: 16px;
+  color: var(--text-dim);
+  margin-top: 10px;
+  max-width: 700px;
+  line-height: 1.6;
+  position: relative;
+}
+
+.hero .github-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 16px;
+  padding: 8px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 13px;
+  font-family: var(--font-mono);
+  transition: all 0.2s;
+  position: relative;
+}
+
+.github-link:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.github-link svg { width: 16px; height: 16px; fill: currentColor; }
+
+.server-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 40px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.server-bar label {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.server-bar input {
+  flex: 1;
+  max-width: 400px;
+  padding: 6px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.server-bar input:focus { outline: none; border-color: var(--accent); }
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #555;
+  transition: background 0.3s;
+}
+
+.status-dot.ok { background: var(--accent); box-shadow: 0 0 8px rgba(34,197,94,0.5); }
+.status-dot.err { background: var(--danger); box-shadow: 0 0 8px rgba(239,68,68,0.5); }
+
+.status-text {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.btn-check {
+  padding: 6px 14px;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: var(--accent);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-check:hover { background: var(--accent); color: #000; }
+
+.main { display: flex; min-height: calc(100vh - 220px); }
+
+.sidebar {
+  width: 360px;
+  min-width: 360px;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.sidebar-tab {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+}
+
+.sidebar-tab button {
+  flex: 1;
+  padding: 12px 8px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-family: var(--font-display);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.sidebar-tab button.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.sidebar-tab button:hover { color: var(--text); }
+
+.panel { display: none; padding: 20px; flex-direction: column; gap: 16px; }
+.panel.active { display: flex; }
+
+.field label {
+  display: block;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+  font-family: var(--font-display);
+  font-weight: 500;
+}
+
+.field input, .field select {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 14px;
+  font-family: var(--font-mono);
+}
+
+.field input:focus, .field select:focus { outline: none; border-color: var(--accent); }
+
+.field-row { display: flex; gap: 12px; }
+.field-row .field { flex: 1; }
+
+.hint {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 4px;
+  line-height: 1.4;
+}
+
+.btn {
+  width: 100%;
+  padding: 12px;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: var(--font-display);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent-dim), var(--accent));
+  color: #fff;
+}
+
+.btn-primary:hover { filter: brightness(1.15); transform: translateY(-1px); }
+.btn-primary:active { transform: translateY(0); }
+
+.btn-blue {
+  background: linear-gradient(135deg, var(--accent-back-dim), var(--accent-back));
+  color: #fff;
+}
+
+.btn-blue:hover { filter: brightness(1.15); transform: translateY(-1px); }
+
+.btn-orange {
+  background: linear-gradient(135deg, #92400e, var(--orange));
+  color: #fff;
+}
+
+.btn-orange:hover { filter: brightness(1.15); }
+
+.btn-danger {
+  background: transparent;
+  border: 1px solid #7f1d1d;
+  color: var(--danger);
+}
+
+.btn-danger:hover { background: #7f1d1d33; }
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none !important;
+}
+
+.map-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+#map {
+  flex: 1;
+  background: #111;
+  min-height: 500px;
+}
+
+.results-drawer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-height: 50%;
+  background: var(--surface);
+  border-top: 2px solid var(--accent);
+  overflow-y: auto;
+  transform: translateY(100%);
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1000;
+}
+
+.results-drawer.open { transform: translateY(0); }
+
+.results-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  z-index: 1;
+}
+
+.results-header h3 {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.results-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.results-close:hover { color: var(--text); }
+
+.results-body { padding: 16px 20px; }
+
+.pin-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  margin-bottom: 12px;
+}
+
+.pin-card.front-card { border-left: 3px solid var(--accent); }
+.pin-card.back-card { border-left: 3px solid var(--accent-back); }
+
+.pin-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.pin-badge {
+  padding: 3px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.pin-badge.front { background: var(--accent-dim); color: var(--accent); }
+.pin-badge.back { background: var(--accent-back-dim); color: var(--accent-back); }
+
+.pin-score {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.pin-score.high { color: var(--accent); }
+.pin-score.mid { color: var(--orange); }
+.pin-score.low { color: var(--danger); }
+
+.pin-details {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.pin-detail-label { color: var(--text-dim); font-family: var(--font-mono); }
+.pin-detail-value { color: var(--text); font-family: var(--font-mono); text-align: right; }
+
+.batch-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+
+.batch-table th {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+}
+
+.batch-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.batch-table tr:hover td { background: var(--surface-2); }
+
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(10,15,26,0.85);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  display: none;
+}
+
+.loading-overlay.active { display: flex; }
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.loading-text {
+  margin-top: 16px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
+.pipeline-section {
+  padding: 40px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.pipeline-section h2 {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 24px;
+}
+
+.pipeline {
+  display: flex;
+  gap: 0;
+  overflow-x: auto;
+  padding-bottom: 12px;
+}
+
+.pipe-step {
+  flex: 1;
+  min-width: 180px;
+  padding: 20px 16px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  position: relative;
+}
+
+.pipe-step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  right: -18px;
+  top: 50%;
+  width: 16px;
+  height: 2px;
+  background: var(--accent);
+  z-index: 1;
+}
+
+.pipe-step:not(:last-child) { margin-right: 18px; }
+
+.pipe-num {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--accent-dim);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: var(--font-display);
+  margin-bottom: 10px;
+}
+
+.pipe-step h4 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 6px;
+}
+
+.pipe-step p {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
+.pipe-tech {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.pipe-tech span {
+  padding: 2px 8px;
+  background: var(--surface-2);
+  border-radius: 4px;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+}
+
+.endpoint-section {
+  padding: 40px;
+  border-top: 1px solid var(--border);
+}
+
+.endpoint-section h2 {
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 24px;
+}
+
+.endpoint-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 16px;
+}
+
+.endpoint-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px;
+  transition: border-color 0.2s;
+}
+
+.endpoint-card:hover { border-color: var(--accent); }
+
+.endpoint-method {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  margin-right: 8px;
+}
+
+.endpoint-method.get { background: #16a34a22; color: #4ade80; }
+.endpoint-method.post { background: #2563eb22; color: #60a5fa; }
+.endpoint-method.delete { background: #dc262622; color: #f87171; }
+
+.endpoint-path {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.endpoint-desc {
+  margin-top: 8px;
+  font-size: 13px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
+.endpoint-params {
+  margin-top: 12px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+}
+
+.endpoint-params code {
+  background: var(--bg);
+  padding: 2px 6px;
+  border-radius: 3px;
+  color: var(--text);
+}
+
+.json-pre {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.json-pre .key { color: #93c5fd; }
+.json-pre .string { color: #86efac; }
+.json-pre .number { color: #fbbf24; }
+.json-pre .null { color: #94a3b8; }
+.json-pre .bool { color: #c084fc; }
+
+.cache-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.stat-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+}
+
+.stat-value {
+  font-family: var(--font-display);
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.stat-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 4px;
+}
+
+.checkbox-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox-field input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+.checkbox-field label {
+  font-size: 13px;
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.leaflet-popup-content-wrapper {
+  background: var(--surface) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 8px !important;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5) !important;
+}
+
+.leaflet-popup-tip { background: var(--surface) !important; }
+
+.leaflet-popup-content {
+  font-family: var(--font-mono) !important;
+  font-size: 12px !important;
+  line-height: 1.6 !important;
+}
+
+.map-instruction {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 800;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 12px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  pointer-events: none;
+  opacity: 0.9;
+}
+
+/* Pin count overlay on map */
+.pin-count-overlay {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  z-index: 800;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.pin-count-overlay.visible { opacity: 0.9; }
+
+.error-msg {
+  background: #7f1d1d33;
+  border: 1px solid #7f1d1d;
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--danger);
+  font-size: 13px;
+  font-family: var(--font-mono);
+}
+
+footer {
+  padding: 20px 40px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+
+.separator { border: none; border-top: 1px solid var(--border); margin: 8px 0; }
+
+@media (max-width: 900px) {
+  .main { flex-direction: column; }
+  .sidebar { width: 100%; min-width: auto; max-height: 40vh; }
+  #map { min-height: 300px; }
+  .pipeline { flex-direction: column; }
+  .pipe-step:not(:last-child)::after { display: none; }
+  .pipe-step:not(:last-child) { margin-right: 0; margin-bottom: 12px; }
+}
+</style>
+</head>
+<body>
+
+<div class="hero">
+  <h1><span class="front">Front</span> / <span class="back">Back</span> Garden Classifier</h1>
+  <p class="subtitle">
+    Automatically distinguishes front gardens (facing the road) from back gardens (away from the road)
+    using aerial imagery, OpenStreetMap data, and computer vision. Optimised for Irish suburban housing
+    with drone delivery pin placement.
+  </p>
+  <a class="github-link" href="https://github.com/tiernan-manna/front-back-garden" target="_blank">
+    <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+    tiernan-manna/front-back-garden
+  </a>
+</div>
+
+<div class="server-bar">
+  <label>API</label>
+  <input type="text" id="apiUrl" value="" placeholder="(same server — leave blank)" />
+  <div class="status-dot" id="statusDot"></div>
+  <span class="status-text" id="statusText">Not checked</span>
+  <button class="btn-check" onclick="checkHealth()">Check</button>
+</div>
+
+<div class="main">
+  <div class="sidebar">
+    <div class="sidebar-tab">
+      <button class="active" data-panel="single">Single Pin</button>
+      <button data-panel="batch">Batch</button>
+      <button data-panel="classify">Classify</button>
+      <button data-panel="manage">Manage</button>
+    </div>
+
+    <!-- Single Pin Panel -->
+    <div class="panel active" id="panel-single">
+      <div class="field">
+        <label>Coordinates</label>
+        <input type="text" id="singleCoords" placeholder="53.380365, -6.386601" />
+        <div class="hint">Click the map to set coordinates, or type lat,lon</div>
+      </div>
+      <div class="field">
+        <label>Or Eircode</label>
+        <input type="text" id="singleEircode" placeholder="D15 YXN8" />
+        <div class="hint">Irish Eircode — geocoded via 5-strategy cascade</div>
+      </div>
+      <div class="field">
+        <label>Tile Source</label>
+        <select id="singleTileSource">
+          <option value="auto">Auto</option>
+          <option value="google">Google</option>
+          <option value="manna">Manna</option>
+        </select>
+      </div>
+      <div class="checkbox-field">
+        <input type="checkbox" id="singleGenMap" checked />
+        <label for="singleGenMap">Generate visualization map</label>
+      </div>
+      <button class="btn btn-primary" id="btnSinglePin" onclick="getSinglePin()">Get Garden Pins</button>
+    </div>
+
+    <!-- Batch Panel -->
+    <div class="panel" id="panel-batch">
+      <div class="field">
+        <label>Center Coordinates</label>
+        <input type="text" id="batchCoords" placeholder="53.380365, -6.386601" />
+        <div class="hint">Click the map to set center point</div>
+      </div>
+      <div class="field">
+        <label>Radius (meters)</label>
+        <input type="number" id="batchRadius" value="200" min="10" max="5000" />
+      </div>
+      <div class="field-row">
+        <div class="field">
+          <label>Garden Type</label>
+          <select id="batchGardenType">
+            <option value="">All</option>
+            <option value="front">Front only</option>
+            <option value="back">Back only</option>
+          </select>
+        </div>
+        <div class="field">
+          <label>Min Score</label>
+          <input type="number" id="batchMinScore" value="0" min="0" max="100" />
+        </div>
+      </div>
+      <div class="field">
+        <label>Tile Source</label>
+        <select id="batchTileSource">
+          <option value="auto">Auto</option>
+          <option value="google">Google</option>
+          <option value="manna">Manna</option>
+        </select>
+      </div>
+      <div class="checkbox-field">
+        <input type="checkbox" id="batchGenMap" />
+        <label for="batchGenMap">Generate visualization map</label>
+      </div>
+      <button class="btn btn-blue" id="btnBatch" onclick="getBatchPins()">Get All Pins in Radius</button>
+      <hr class="separator" />
+      <div class="hint">For large areas, precompute first for speed:</div>
+      <button class="btn btn-orange" id="btnPrecompute" onclick="precomputeArea()">Precompute Area</button>
+    </div>
+
+    <!-- Classify Panel -->
+    <div class="panel" id="panel-classify">
+      <div class="field">
+        <label>Coordinates</label>
+        <input type="text" id="classifyCoords" placeholder="53.380365, -6.386601" />
+        <div class="hint">Click the map to set coordinates</div>
+      </div>
+      <div class="field">
+        <label>Tile Source</label>
+        <select id="classifyTileSource">
+          <option value="auto">Auto</option>
+          <option value="google">Google</option>
+          <option value="manna">Manna</option>
+        </select>
+      </div>
+      <button class="btn btn-primary" id="btnClassify" onclick="classifyPoint()">Classify Point</button>
+      <div id="classifyResult"></div>
+    </div>
+
+    <!-- Manage Panel -->
+    <div class="panel" id="panel-manage">
+      <h4 style="font-family:var(--font-display);font-size:14px;margin-bottom:4px;">Cache Management</h4>
+      <p class="hint">View cache stats and manage precomputed data.</p>
+      <button class="btn btn-primary" onclick="getCacheStats()">Get Cache Stats</button>
+      <div id="cacheStatsResult"></div>
+      <hr class="separator" />
+      <button class="btn btn-danger" onclick="clearCache()">Clear All Caches</button>
+    </div>
+  </div>
+
+  <div class="map-area">
+    <div class="map-instruction">Click the map to set coordinates</div>
+    <div id="map"></div>
+    <div class="pin-count-overlay" id="pinCountOverlay"></div>
+    <div class="loading-overlay" id="loadingOverlay">
+      <div class="spinner"></div>
+      <div class="loading-text" id="loadingText">Processing...</div>
+    </div>
+    <div class="results-drawer" id="resultsDrawer">
+      <div class="results-header">
+        <h3 id="resultsTitle">Results</h3>
+        <button class="results-close" onclick="closeResults()">&times;</button>
+      </div>
+      <div class="results-body" id="resultsBody"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Pipeline Section -->
+<div class="pipeline-section">
+  <h2>How It Works</h2>
+  <div class="pipeline">
+    <div class="pipe-step">
+      <div class="pipe-num">1</div>
+      <h4>Aerial Imagery</h4>
+      <p>Fetches satellite/aerial photos from Google Tiles API. Stitches multiple 256px tiles into a single high-resolution image. Auto-selects zoom level to stay within memory limits.</p>
+      <div class="pipe-tech"><span>Google Tiles API</span><span>Pillow</span></div>
+    </div>
+    <div class="pipe-step">
+      <div class="pipe-num">2</div>
+      <h4>OSM Data</h4>
+      <p>Retrieves building footprints, roads, driveways, address polygons, and property boundaries from OpenStreetMap via the Overpass API. All free, no API key needed.</p>
+      <div class="pipe-tech"><span>Overpass API</span><span>GeoPandas</span><span>Shapely</span></div>
+    </div>
+    <div class="pipe-step">
+      <div class="pipe-num">3</div>
+      <h4>Vegetation Detection</h4>
+      <p>Multi-range HSV colour segmentation catches all grass types (healthy, dry, shadowed). Excess Green Index confirmation. Texture-based grass/tree separation using coefficient of variation.</p>
+      <div class="pipe-tech"><span>OpenCV</span><span>HSV + ExG</span><span>NumPy</span></div>
+    </div>
+    <div class="pipe-step">
+      <div class="pipe-num">4</div>
+      <h4>Classification</h4>
+      <p>STRtree spatial indexes for O(log n) road lookups. Address-matching, driveway-matching, road-fallback. Consensus correction + outlier detection. Driveway override.</p>
+      <div class="pipe-tech"><span>STRtree</span><span>SciPy</span><span>Heuristics</span></div>
+    </div>
+    <div class="pipe-step">
+      <div class="pipe-num">5</div>
+      <h4>Pin Placement</h4>
+      <p>One front + one back pin per building. 4-attempt fallback cascade. Property border enforcement, lateral corridor constraint, tree canopy penalty, boundary deduplication.</p>
+      <div class="pipe-tech"><span>Scoring 0-100</span><span>Grass/Paved/Drive</span></div>
+    </div>
+    <div class="pipe-step">
+      <div class="pipe-num">6</div>
+      <h4>Output</h4>
+      <p>Segmentation mask, delivery pins with scores, map visualisation, REST API responses. Precomputed results cached for instant lookups.</p>
+      <div class="pipe-tech"><span>FastAPI</span><span>Cache</span><span>PNG Maps</span></div>
+    </div>
+  </div>
+</div>
+
+<!-- API Reference -->
+<div class="endpoint-section">
+  <h2>API Reference</h2>
+  <div class="endpoint-grid">
+    <div class="endpoint-card">
+      <span class="endpoint-method get">GET</span>
+      <span class="endpoint-path">/health</span>
+      <p class="endpoint-desc">Health check. Returns status, timestamp, and API version.</p>
+    </div>
+    <div class="endpoint-card">
+      <span class="endpoint-method post">POST</span>
+      <span class="endpoint-path">/api/garden-pins</span>
+      <p class="endpoint-desc">Get front and back garden delivery pins for a single house. Accepts lat/lon, a coords string, or an Irish Eircode (geocoded via 5-strategy cascade).</p>
+      <div class="endpoint-params">
+        Params: <code>lat</code> <code>lon</code> <code>coords</code> <code>eircode</code> <code>generate_map</code> <code>tile_source</code>
+      </div>
+    </div>
+    <div class="endpoint-card">
+      <span class="endpoint-method post">POST</span>
+      <span class="endpoint-path">/api/garden-pins/batch</span>
+      <p class="endpoint-desc">Get all delivery pins within a radius. Returns front and back pins for every building. Precompute first for instant results.</p>
+      <div class="endpoint-params">
+        Params: <code>lat</code> <code>lon</code> <code>radius_m</code> <code>garden_type</code> <code>min_score</code> <code>generate_map</code>
+      </div>
+    </div>
+    <div class="endpoint-card">
+      <span class="endpoint-method post">POST</span>
+      <span class="endpoint-path">/api/classify</span>
+      <p class="endpoint-desc">Classify a GPS coordinate as front garden, back garden, building, road, etc. Returns classification, surface type, and delivery suitability score (0-100).</p>
+      <div class="endpoint-params">
+        Params: <code>lat</code> <code>lon</code> <code>tile_source</code>
+      </div>
+    </div>
+    <div class="endpoint-card">
+      <span class="endpoint-method post">POST</span>
+      <span class="endpoint-path">/api/precompute</span>
+      <p class="endpoint-desc">Precompute classification for a large area. Single-pass processing — 500m radius in ~1-3 minutes. Subsequent batch queries are near-instant.</p>
+      <div class="endpoint-params">
+        Params: <code>lat</code> <code>lon</code> <code>radius_m</code> <code>skip_cache</code>
+      </div>
+    </div>
+    <div class="endpoint-card">
+      <span class="endpoint-method get">GET</span>
+      <span class="endpoint-path">/api/cache/stats</span>
+      <p class="endpoint-desc">Cache statistics: fast cache entries, precomputed areas, total pins stored.</p>
+    </div>
+    <div class="endpoint-card">
+      <span class="endpoint-method delete">DELETE</span>
+      <span class="endpoint-path">/api/cache</span>
+      <p class="endpoint-desc">Clear all caches — fast point cache and precomputed area data.</p>
+    </div>
+    <div class="endpoint-card">
+      <span class="endpoint-method post">POST</span>
+      <span class="endpoint-path">/api/shutdown</span>
+      <p class="endpoint-desc">Gracefully shut down the server. Sets shutdown flag so in-flight tile fetches abort, then sends SIGTERM.</p>
+    </div>
+  </div>
+</div>
+
+<footer>
+  <span>Garden Classifier v1.1.0 — Manna Aero</span>
+  <a href="https://github.com/tiernan-manna/front-back-garden" target="_blank">Source on GitHub</a>
+</footer>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+const DEFAULT_CENTER = [53.375142, -6.383740];
+
+// Canvas renderer — all markers share a single <canvas> element.
+// Handles 10 000+ pins without DOM overhead. Padding keeps markers
+// visible slightly outside the viewport during panning.
+const canvasRenderer = L.canvas({ padding: 0.5 });
+
+const map = L.map('map', { zoomControl: true }).setView(DEFAULT_CENTER, 16);
+L.tileLayer('https://tiles.manna.aero/{z}/{x}/{y}.png', {
+  maxZoom: 20,
+  attribution: 'Manna Tiles'
+}).addTo(map);
+
+let clickMarker = null;
+let pinLayer    = L.layerGroup().addTo(map);
+let radiusCircle = null;
+let allPins     = [];   // full dataset from last batch call
+const pinCountEl = document.getElementById('pinCountOverlay');
+
+// ---------------------------------------------------------------------------
+// buildUrl — same-origin by default (page lives at /garden/).
+// Strips the leading slash so the path is relative to the current page URL,
+// which means the browser resolves it correctly through the nginx /garden/ prefix.
+// When the user sets a custom API base in the input, prefix with that instead.
+// ---------------------------------------------------------------------------
+function getApiBase() {
+  return document.getElementById('apiUrl').value.replace(/\/+$/, '');
+}
+
+function buildUrl(path) {
+  const base = getApiBase();
+  if (base) return base + path;
+  // Relative — strip leading slash so it resolves from the page URL
+  return path.replace(/^\//, '');
+}
+
+function showLoading(text) {
+  document.getElementById('loadingText').textContent = text || 'Processing...';
+  document.getElementById('loadingOverlay').classList.add('active');
+}
+
+function hideLoading() {
+  document.getElementById('loadingOverlay').classList.remove('active');
+}
+
+function showResults(title, html) {
+  document.getElementById('resultsTitle').textContent = title;
+  document.getElementById('resultsBody').innerHTML = html;
+  document.getElementById('resultsDrawer').classList.add('open');
+}
+
+function closeResults() {
+  document.getElementById('resultsDrawer').classList.remove('open');
+}
+
+function syntaxHighlight(json) {
+  if (typeof json !== 'string') json = JSON.stringify(json, null, 2);
+  json = json.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return json.replace(/("(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function(match) {
+    let cls = 'number';
+    if (/^"/.test(match)) {
+      if (/:$/.test(match)) { cls = 'key'; }
+      else { cls = 'string'; }
+    } else if (/true|false/.test(match)) { cls = 'bool'; }
+    else if (/null/.test(match)) { cls = 'null'; }
+    return '<span class="' + cls + '">' + match + '</span>';
+  });
+}
+
+function scoreClass(score) {
+  if (score >= 75) return 'high';
+  if (score >= 40) return 'mid';
+  return 'low';
+}
+
+function pinCardHtml(pin, type) {
+  if (!pin) return `<div class="pin-card ${type}-card"><div class="pin-card-header"><span class="pin-badge ${type}">${type}</span></div><p style="color:var(--text-dim);font-size:13px;">No ${type} garden found</p></div>`;
+  const score = pin.score || 0;
+  return `
+    <div class="pin-card ${type}-card">
+      <div class="pin-card-header">
+        <span class="pin-badge ${type}">${type}</span>
+        <span class="pin-score ${scoreClass(score)}">${Math.round(score)}</span>
+      </div>
+      <div class="pin-details">
+        <span class="pin-detail-label">Surface</span>
+        <span class="pin-detail-value">${pin.surface_type || '—'}</span>
+        <span class="pin-detail-label">Lat</span>
+        <span class="pin-detail-value">${(pin.lat || 0).toFixed(6)}</span>
+        <span class="pin-detail-label">Lon</span>
+        <span class="pin-detail-value">${(pin.lon || 0).toFixed(6)}</span>
+        <span class="pin-detail-label">Garden Type</span>
+        <span class="pin-detail-value">${pin.garden_type || type}</span>
+        ${pin.distance_to_building_m !== undefined ? `<span class="pin-detail-label">Dist to building</span><span class="pin-detail-value">${pin.distance_to_building_m.toFixed(1)}m</span>` : ''}
+      </div>
+    </div>`;
+}
+
+// ---------------------------------------------------------------------------
+// Canvas pin rendering with viewport culling
+//
+// Strategy: store ALL pins from the batch response in `allPins`.
+// On every renderVisiblePins() call, clear the layer and re-add only pins
+// that fall within the current map bounds (+ 20% padding buffer so pins
+// don't pop in abruptly while panning).
+//
+// With L.circleMarker + canvasRenderer there is no per-marker DOM node,
+// so even thousands of visible pins render instantly on the GPU canvas.
+// ---------------------------------------------------------------------------
+function renderVisiblePins() {
+  pinLayer.clearLayers();
+  if (!allPins.length) return;
+
+  const bounds = map.getBounds().pad(0.2);
+  let rendered = 0;
+
+  for (let i = 0; i < allPins.length; i++) {
+    const pin = allPins[i];
+    if (!pin.lat || !pin.lon) continue;
+    if (!bounds.contains([pin.lat, pin.lon])) continue;
+
+    const isNoGarden = pin.surface_type === 'no_garden';
+    const fillColor  = isNoGarden ? '#64748b'
+                     : pin.garden_type === 'front' ? '#22c55e' : '#3b82f6';
+
+    L.circleMarker([pin.lat, pin.lon], {
+      renderer:    canvasRenderer,
+      radius:      isNoGarden ? 3 : 5,
+      fillColor,
+      color:       '#fff',
+      weight:      1,
+      opacity:     1,
+      fillOpacity: isNoGarden ? 0.35 : 0.85,
+    }).bindPopup(
+      `<b>${pin.garden_type || '?'}</b><br>` +
+      `Score: ${Math.round(pin.score || 0)}<br>` +
+      `Surface: ${pin.surface_type || '—'}`
+    ).addTo(pinLayer);
+
+    rendered++;
+  }
+
+  pinCountEl.textContent = `${rendered.toLocaleString()} / ${allPins.length.toLocaleString()} pins in view`;
+  pinCountEl.classList.toggle('visible', allPins.length > 0);
+}
+
+map.on('moveend zoomend', renderVisiblePins);
+
+function clearPins() {
+  pinLayer.clearLayers();
+  allPins = [];
+  if (radiusCircle) { map.removeLayer(radiusCircle); radiusCircle = null; }
+  pinCountEl.classList.remove('visible');
+}
+
+// ---------------------------------------------------------------------------
+// Map click — populate all coordinate fields
+// ---------------------------------------------------------------------------
+map.on('click', function(e) {
+  const lat    = e.latlng.lat.toFixed(6);
+  const lon    = e.latlng.lng.toFixed(6);
+  const coords = `${lat}, ${lon}`;
+
+  document.getElementById('singleCoords').value   = coords;
+  document.getElementById('batchCoords').value    = coords;
+  document.getElementById('classifyCoords').value = coords;
+
+  if (clickMarker) map.removeLayer(clickMarker);
+  clickMarker = L.circleMarker(e.latlng, {
+    renderer:    canvasRenderer,
+    radius:      7,
+    fillColor:   '#f59e0b',
+    color:       '#fff',
+    weight:      2,
+    fillOpacity: 0.9,
+  }).addTo(map);
+});
+
+// Sidebar tabs
+document.querySelectorAll('.sidebar-tab button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.sidebar-tab button').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+    btn.classList.add('active');
+    document.getElementById('panel-' + btn.dataset.panel).classList.add('active');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+async function checkHealth() {
+  const dot  = document.getElementById('statusDot');
+  const text = document.getElementById('statusText');
+  try {
+    const r = await fetch(buildUrl('/health'));
+    const d = await r.json();
+    dot.className   = 'status-dot ok';
+    text.textContent = `v${d.version} — healthy`;
+  } catch (e) {
+    dot.className   = 'status-dot err';
+    text.textContent = 'Unreachable';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single Pin
+// ---------------------------------------------------------------------------
+async function getSinglePin() {
+  const coords   = document.getElementById('singleCoords').value.trim();
+  const eircode  = document.getElementById('singleEircode').value.trim();
+  const tileSource = document.getElementById('singleTileSource').value;
+  const genMap   = document.getElementById('singleGenMap').checked;
+
+  if (!coords && !eircode) { alert('Enter coordinates or an eircode'); return; }
+
+  const body = { tile_source: tileSource, generate_map: genMap };
+  if (coords)  body.coords  = coords;
+  if (eircode) body.eircode = eircode;
+
+  clearPins();
+
+  const startMs = Date.now();
+  let timerInterval = setInterval(() => {
+    const s = Math.round((Date.now() - startMs) / 1000);
+    showLoading(`Finding garden pins… ${s}s — satellite imagery + ML inference can take 60–120s`);
+  }, 1000);
+  showLoading('Finding garden pins…');
+
+  const showTimeoutError = () => {
+    const retryHtml = `
+      <div class="error-msg" style="margin-bottom:10px;">
+        <strong>Gateway Timeout (504)</strong> — the garden service needs 60–120 s to fetch satellite imagery and run ML inference,
+        but the load balancer cut the connection after 60 s.<br><br>
+        <em>If this is the first request for this location, imagery may now be cached — try again:</em>
+      </div>
+      <button class="btn btn-primary" onclick="getSinglePin()">Retry</button>`;
+    showResults('Timeout — please retry', retryHtml);
+  };
+
+  try {
+    const r = await fetch(buildUrl('/api/garden-pins'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    clearInterval(timerInterval);
+    hideLoading();
+
+    if (r.status === 504 || r.status === 502) { showTimeoutError(); return; }
+
+    let d;
+    try { d = await r.json(); } catch (_) { showResults('Error', `<div class="error-msg">HTTP ${r.status} — unexpected response</div>`); return; }
+    if (!r.ok) { showResults('Error', `<div class="error-msg">${d.detail || JSON.stringify(d)}</div>`); return; }
+
+    if (d.front && d.front.lat) allPins.push(d.front);
+    if (d.back  && d.back.lat)  allPins.push(d.back);
+    renderVisiblePins();
+
+    if (d.metadata && d.metadata.input_lat) {
+      map.setView([d.metadata.input_lat, d.metadata.input_lon], 18);
+    }
+
+    let html = pinCardHtml(d.front, 'front') + pinCardHtml(d.back, 'back');
+
+    if (d.map_url) {
+      const mapSrc = d.map_url.startsWith('http') ? d.map_url : buildUrl(d.map_url);
+      html += `<div style="margin-top:12px;"><img src="${mapSrc}" style="width:100%;border-radius:8px;border:1px solid var(--border);" /></div>`;
+    }
+
+    html += `<details style="margin-top:12px;"><summary style="cursor:pointer;color:var(--text-dim);font-size:12px;">Raw JSON response</summary><div class="json-pre">${syntaxHighlight(d)}</div></details>`;
+
+    const elapsed = d.metadata?.elapsed_seconds;
+    showResults(`Single Pin Results${elapsed ? ` (${elapsed}s)` : ''}`, html);
+
+  } catch (e) {
+    clearInterval(timerInterval);
+    hideLoading();
+    if (e.name === 'TypeError' && e.message.includes('fetch')) {
+      showTimeoutError();
+    } else {
+      showResults('Error', `<div class="error-msg">${e.message}\n${e.stack}</div>`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Batch Pins
+// ---------------------------------------------------------------------------
+async function getBatchPins() {
+  const coords = document.getElementById('batchCoords').value.trim();
+  if (!coords) { alert('Enter center coordinates'); return; }
+
+  const radius     = parseInt(document.getElementById('batchRadius').value) || 200;
+  const gardenType = document.getElementById('batchGardenType').value || null;
+  const minScore   = parseFloat(document.getElementById('batchMinScore').value) || 0;
+  const tileSource = document.getElementById('batchTileSource').value;
+  const genMap     = document.getElementById('batchGenMap').checked;
+
+  const body = { coords, radius_m: radius, tile_source: tileSource, generate_map: genMap, min_score: minScore };
+  if (gardenType) body.garden_type = gardenType;
+
+  showLoading(`Scanning ${radius}m radius...`);
+  clearPins();
+
+  try {
+    const r = await fetch(buildUrl('/api/garden-pins/batch'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    const d = await r.json();
+    hideLoading();
+
+    if (!r.ok) { showResults('Error', `<div class="error-msg">${d.detail || JSON.stringify(d)}</div>`); return; }
+
+    const [lat, lon] = coords.split(',').map(s => parseFloat(s.trim()));
+    radiusCircle = L.circle([lat, lon], {
+      radius,
+      color:       '#22c55e',
+      fillColor:   '#22c55e',
+      fillOpacity: 0.05,
+      weight:      1,
+      dashArray:   '6 4'
+    }).addTo(map);
+
+    // Store all pins and let the viewport-culled renderer handle display
+    allPins = d.pins || [];
+    map.fitBounds(radiusCircle.getBounds(), { padding: [30, 30] });
+    // fitBounds fires moveend → renderVisiblePins() runs automatically
+
+    const front    = allPins.filter(p => p.garden_type === 'front' && p.surface_type !== 'no_garden');
+    const back     = allPins.filter(p => p.garden_type === 'back'  && p.surface_type !== 'no_garden');
+    const noGarden = allPins.filter(p => p.surface_type === 'no_garden');
+
+    let html = `<div style="margin-bottom:12px;font-size:13px;">
+      <span style="color:var(--accent);">${front.length} front</span> &middot;
+      <span style="color:var(--accent-back);">${back.length} back</span> &middot;
+      <span style="color:var(--text-dim);">${noGarden.length} no garden</span> &middot;
+      <span>${d.count} total pins</span>
+    </div>`;
+
+    if (d.map_url) {
+      const mapSrc = d.map_url.startsWith('http') ? d.map_url : buildUrl(d.map_url);
+      html += `<div style="margin-bottom:12px;"><img src="${mapSrc}" style="width:100%;border-radius:8px;border:1px solid var(--border);" /></div>`;
+    }
+
+    const tableData = allPins.filter(p => p.surface_type !== 'no_garden').slice(0, 100);
+    if (tableData.length > 0) {
+      html += `<table class="batch-table"><thead><tr><th>Type</th><th>Surface</th><th>Score</th><th>Lat</th><th>Lon</th></tr></thead><tbody>`;
+      tableData.forEach(p => {
+        const color = p.garden_type === 'front' ? 'var(--accent)' : 'var(--accent-back)';
+        html += `<tr><td style="color:${color}">${p.garden_type}</td><td>${p.surface_type}</td><td>${Math.round(p.score || 0)}</td><td>${(p.lat||0).toFixed(6)}</td><td>${(p.lon||0).toFixed(6)}</td></tr>`;
+      });
+      html += `</tbody></table>`;
+      if (allPins.length > 100) html += `<div class="hint" style="margin-top:8px;">Showing first 100 of ${allPins.length} pins in table</div>`;
+    }
+
+    html += `<details style="margin-top:12px;"><summary style="cursor:pointer;color:var(--text-dim);font-size:12px;">Raw JSON (${d.count} pins)</summary><div class="json-pre">${syntaxHighlight(d)}</div></details>`;
+
+    const elapsed = d.metadata?.elapsed_seconds;
+    const cached  = d.metadata?.from_cache ? ' (cached)' : '';
+    showResults(`Batch Results — ${d.count} pins${cached}${elapsed ? ` in ${elapsed}s` : ''}`, html);
+
+  } catch (e) {
+    hideLoading();
+    showResults('Error', `<div class="error-msg">${e.message}\n${e.stack}</div>`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Precompute
+// ---------------------------------------------------------------------------
+async function precomputeArea() {
+  const coords = document.getElementById('batchCoords').value.trim();
+  if (!coords) { alert('Enter center coordinates'); return; }
+
+  const radius     = parseInt(document.getElementById('batchRadius').value) || 200;
+  const tileSource = document.getElementById('batchTileSource').value;
+  const [lat, lon] = coords.split(',').map(s => parseFloat(s.trim()));
+
+  showLoading(`Precomputing ${radius}m radius — this may take 1-3 minutes...`);
+
+  try {
+    const r = await fetch(buildUrl('/api/precompute'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lat, lon, radius_m: radius, tile_source: tileSource })
+    });
+    const d = await r.json();
+    hideLoading();
+
+    let html = `<div style="margin-bottom:12px;font-size:14px;color:var(--accent);">${d.status === 'completed' ? 'Precomputation complete' : d.status}</div>`;
+    html += `<p style="font-size:13px;color:var(--text-dim);margin-bottom:12px;">${d.message}</p>`;
+    if (d.summary) html += `<div class="json-pre">${syntaxHighlight(d.summary)}</div>`;
+    showResults('Precompute Result', html);
+
+  } catch (e) {
+    hideLoading();
+    showResults('Error', `<div class="error-msg">${e.message}\n${e.stack}</div>`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Classify
+// ---------------------------------------------------------------------------
+async function classifyPoint() {
+  const coords = document.getElementById('classifyCoords').value.trim();
+  if (!coords) { alert('Enter coordinates'); return; }
+
+  const [lat, lon] = coords.split(',').map(s => parseFloat(s.trim()));
+  const tileSource = document.getElementById('classifyTileSource').value;
+
+  showLoading('Classifying point...');
+
+  try {
+    const r = await fetch(buildUrl('/api/classify'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lat, lon, tile_source: tileSource })
+    });
+    const d = await r.json();
+    hideLoading();
+
+    if (!r.ok) {
+      document.getElementById('classifyResult').innerHTML = `<div class="error-msg" style="margin-top:12px;">${d.detail || JSON.stringify(d)}</div>`;
+      return;
+    }
+
+    const classColor = d.classification?.includes('front') ? 'var(--accent)'
+                     : d.classification?.includes('back')  ? 'var(--accent-back)'
+                     : 'var(--text-dim)';
+
+    document.getElementById('classifyResult').innerHTML = `
+      <div class="pin-card" style="margin-top:12px;border-left:3px solid ${classColor};">
+        <div style="font-size:18px;font-weight:700;font-family:var(--font-display);color:${classColor};margin-bottom:8px;">${d.classification || 'unknown'}</div>
+        <div class="pin-details">
+          <span class="pin-detail-label">Surface</span>
+          <span class="pin-detail-value">${d.surface_type || '—'}</span>
+          <span class="pin-detail-label">Score</span>
+          <span class="pin-detail-value ${scoreClass(d.score || 0)}">${Math.round(d.score || 0)}</span>
+          <span class="pin-detail-label">Dist to building</span>
+          <span class="pin-detail-value">${d.distance_to_building_m != null ? d.distance_to_building_m.toFixed(1) + 'm' : '—'}</span>
+        </div>
+      </div>
+      <details style="margin-top:8px;"><summary style="cursor:pointer;color:var(--text-dim);font-size:12px;">Raw JSON</summary><div class="json-pre">${syntaxHighlight(d)}</div></details>`;
+
+  } catch (e) {
+    hideLoading();
+    document.getElementById('classifyResult').innerHTML = `<div class="error-msg" style="margin-top:12px;">${e.message}\n${e.stack}</div>`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cache management
+// ---------------------------------------------------------------------------
+async function getCacheStats() {
+  try {
+    const r = await fetch(buildUrl('/api/cache/stats'));
+    const d = await r.json();
+    document.getElementById('cacheStatsResult').innerHTML = `
+      <div class="cache-stats">
+        <div class="stat-card"><div class="stat-value">${d.fast_cache_entries}</div><div class="stat-label">Fast Cache</div></div>
+        <div class="stat-card"><div class="stat-value">${d.precompute_areas}</div><div class="stat-label">Precomputed Areas</div></div>
+        <div class="stat-card"><div class="stat-value">${d.total_pins}</div><div class="stat-label">Total Pins</div></div>
+      </div>`;
+  } catch (e) {
+    document.getElementById('cacheStatsResult').innerHTML = `<div class="error-msg" style="margin-top:12px;">${e.message}</div>`;
+  }
+}
+
+async function clearCache() {
+  if (!confirm('Clear all caches? This cannot be undone.')) return;
+  try {
+    const r = await fetch(buildUrl('/api/cache'), { method: 'DELETE' });
+    const d = await r.json();
+    document.getElementById('cacheStatsResult').innerHTML = `<div style="margin-top:12px;color:var(--accent);font-size:13px;">${d.message}</div>`;
+  } catch (e) {
+    document.getElementById('cacheStatsResult').innerHTML = `<div class="error-msg" style="margin-top:12px;">${e.message}</div>`;
+  }
+}
+
+checkHealth();
+</script>
+</body>
+</html>

--- a/front-back-garden/src/precompute.py
+++ b/front-back-garden/src/precompute.py
@@ -1397,6 +1397,11 @@ class PrecomputeManager:
 
             all_pins.extend(chunk_pins)
 
+        # Release the full image now that all chunks are cropped — it can be
+        # ~880 MB for a 3 km radius and is no longer needed.
+        del full_image
+        gc.collect()
+
         # Global post-processing: neighbor consistency
         _log(f"[3/3] Post-processing {len(all_pins)} pins...")
         cos_lat = np.cos(np.radians(center_lat))


### PR DESCRIPTION
## Summary

Two separate changes landed on this branch:

### 1. fix(precompute): release full-area image after chunk loop to prevent OOM
Releases the full-area satellite image from memory after processing all chunks, preventing OOM crashes during large-radius precompute jobs.

### 2. feat(ui): garden classifier frontend — co-located, canvas rendering, viewport culling

- Moves the garden classifier frontend (previously `garden-classifier.html` in `manna_tiny_web_server`) into this repo as `front-back-garden/index.html`, served at `GET /` by FastAPI
- Replaces DOM-based Leaflet markers (`L.marker` + `divIcon`) with canvas-based `L.circleMarker` using `L.canvas()` renderer — eliminates per-pin DOM nodes, GPU-accelerated
- Adds viewport culling: only pins within the current map bounds render; layer clears and redraws on every `moveend`/`zoomend` — makes 3km radius (10k+ pins) fully usable without lag
- Removes CORS proxy dependency: uses same-origin relative paths since UI is served from the same service

## Why the 3km lag is fixed

Previously every pin was a real HTML `<div>`. At 3km radius with hundreds of buildings you get thousands of DOM nodes simultaneously — causing the freeze. Canvas rendering shares a single `<canvas>` element for all pins, and viewport culling ensures only what's on screen is ever drawn.

## Changes

- `front-back-garden/index.html` — new co-located UI
- `front-back-garden/api.py` — added `GET /` route via `FileResponse`; `fix/precompute` OOM fix

## Test plan

- [ ] Precompute a large area — no OOM crash
- [ ] Visit `/garden/` on the deployed service — UI loads
- [ ] Health check dot goes green
- [ ] Batch at 3km radius renders without lag; pin count overlay updates on pan/zoom
- [ ] `manna_tiny_web_server` proxy route removed, old HTML deleted