### PR TITLE
fix(api): serve index.html at root so the frontend is reachable

### DIFF
--- a/front-back-garden/api.py
+++ b/front-back-garden/api.py
@@ -524,6 +524,13 @@ STATIC_DIR = Path(config.OUTPUT_DIR) / "maps"
 STATIC_DIR.mkdir(parents=True, exist_ok=True)
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
+_FRONTEND = Path(__file__).parent / "index.html"
+
+@app.get("/", include_in_schema=False)
+async def serve_frontend():
+    """Serve the garden classifier frontend."""
+    return FileResponse(str(_FRONTEND), media_type="text/html")
+
 
 def generate_pins_map(
     pins: List[Dict[str, Any]],


### PR DESCRIPTION
## Summary

- `api.py` had `index.html` in the repo but never served it — there was no route for `GET /`
- Added a root route that returns `index.html` via `FileResponse`
- Frontend is now reachable at `https://manna-int.m4mga3.com/garden/`

## Test plan
- [ ] `curl https://manna-int.m4mga3.com/garden/` returns 200 with HTML
- [ ] Opening `https://manna-int.m4mga3.com/garden/` in a browser loads the garden classifier UI

Made with [Cursor](https://cursor.com)