### PR TITLE
perf(precompute): parallelise chunk processing with semaphore + RAM gate

### DIFF
--- a/front-back-garden/api.py
+++ b/front-back-garden/api.py
@@ -1028,6 +1028,18 @@ async def get_active_precomputes():
     return {"active_jobs": active}
 
 
+@app.get("/api/precompute/check")
+async def check_precompute_cached(lat: float, lon: float, radius_m: float):
+    """
+    Lightweight cache probe — returns whether an area is already precomputed.
+
+    Never triggers a precompute. Safe to call on every map click or input change.
+    """
+    manager = PrecomputeManager()
+    cached = manager.is_area_cached(lat, lon, radius_m)
+    return {"cached": cached, "lat": lat, "lon": lon, "radius_m": radius_m}
+
+
 @app.get("/api/cache/stats", response_model=CacheStatsResponse)
 async def get_cache_stats():
     """Get statistics about the caches."""

--- a/front-back-garden/index.html
+++ b/front-back-garden/index.html
@@ -1437,7 +1437,7 @@ function buildUrl(path) {
 
 // ---------------------------------------------------------------------------
 // Pipeline step definitions (for progress bar)
-// Used for both 5-step (single-pass) and 3-step (chunked) modes.
+// Used for both 4-step (single-pass) and 3-step (chunked) modes.
 // ---------------------------------------------------------------------------
 const PIPELINE_4 = [
   { label: '1 · Fetch',    name: 'Fetching imagery + OSM' },
@@ -1451,18 +1451,77 @@ const PIPELINE_3 = [
   { label: '3 · Post',    name: 'Post-processing' },
 ];
 
+// ---------------------------------------------------------------------------
+// ETA model — empirical timings at 3 concurrent heavy-phase slots, uncached
+// ---------------------------------------------------------------------------
+// Step weights: fraction of total wall-time each step typically takes.
+const STEP_WEIGHTS_4 = [0.07, 0.24, 0.40, 0.29]; // Fetch, Veg, Classify, Pins
+const STEP_WEIGHTS_3 = [0.20, 0.75, 0.05];        // Fetch, Chunks, Post
+
+// [radius_m, seconds] — server measurements, 3 concurrent slots, uncached.
+const _TIMING_SAMPLES = [
+  [  200,  150],
+  [  500,  230],
+  [ 1000,  230],
+  [ 1500,  440],
+  [ 2000,  730],
+  [ 3000, 1600],
+];
+
+function _estimateTotalS(radius_m, nSlots) {
+  nSlots = Math.max(1, nSlots || 3);
+  const s = _TIMING_SAMPLES;
+  let baseS;
+  if (radius_m <= s[0][0]) {
+    baseS = s[0][1];
+  } else if (radius_m >= s[s.length - 1][0]) {
+    const [r1, t1] = s[s.length - 2], [r2, t2] = s[s.length - 1];
+    baseS = t2 * Math.pow(radius_m / r2, Math.log(t2 / t1) / Math.log(r2 / r1));
+  } else {
+    for (let i = 0; i < s.length - 1; i++) {
+      if (radius_m <= s[i + 1][0]) {
+        const [r0, t0] = s[i], [r1, t1] = s[i + 1];
+        baseS = t0 + (t1 - t0) * (radius_m - r0) / (r1 - r0);
+        break;
+      }
+    }
+  }
+  // Chunk step (~75% of chunked pipeline) scales inversely with slot count.
+  // Single-pass (<= ~600m) isn't chunk-bound so no slot adjustment there.
+  if (nSlots !== 3 && radius_m > 600) {
+    const chunkFrac = STEP_WEIGHTS_3[1];
+    baseS = baseS * (1 - chunkFrac) + baseS * chunkFrac * (3 / nSlots);
+  }
+  return Math.round(baseS);
+}
+
+// ---------------------------------------------------------------------------
 // Progress bar state
-let _pbSteps       = PIPELINE_4;
-let _pbCurrent     = -1;   // index into _pbSteps
-let _pbStartMs     = 0;    // wall-clock ms when precompute started
-let _pbStepStartMs = 0;    // when current step started
-let _pbTickTimer   = null; // interval for live elapsed tick
+// ---------------------------------------------------------------------------
+let _pbSteps        = PIPELINE_4;
+let _pbCurrent      = -1;
+let _pbStartMs      = 0;
+let _pbStepStartMs  = 0;
+let _pbTickTimer    = null;
+let _pbTotalEstS    = 0;      // estimated total seconds for this run
+let _pbRadius       = 200;    // radius of the current precompute
+let _pbNSlots       = 3;      // effective concurrent heavy-phase slots
+let _pbChunksTotal  = 0;      // total chunks (chunked pipeline only)
+let _pbChunksDone   = 0;      // completed chunks so far
+
+// Concurrent mid-flight detection
+let _pbPollTimer    = null;
+let _pbJobKey       = null;
+let _pbActiveCount  = 1;
 
 function _initProgressBar(steps) {
-  _pbSteps    = steps;
-  _pbCurrent  = -1;
-  _pbStartMs  = Date.now();
+  _pbSteps       = steps;
+  _pbCurrent     = -1;
+  _pbStartMs     = Date.now();
   _pbStepStartMs = Date.now();
+  _pbChunksTotal = 0;
+  _pbChunksDone  = 0;
+  _pbTotalEstS   = _estimateTotalS(_pbRadius, _pbNSlots);
 
   const dotsEl = document.getElementById('progressStepDots');
   dotsEl.innerHTML = '';
@@ -1478,29 +1537,40 @@ function _initProgressBar(steps) {
   document.getElementById('progressStepName').textContent = '';
   document.getElementById('progressEta').textContent = '';
 
-  // Live elapsed ticker so the UI never looks frozen mid-step
   if (_pbTickTimer) clearInterval(_pbTickTimer);
-  _pbTickTimer = setInterval(() => {
-    if (_pbCurrent < 0) return;
-    const etaEl = document.getElementById('progressEta');
-    if (!etaEl || etaEl.dataset.finalised === '1') return;
-    const stepSec  = ((Date.now() - _pbStepStartMs) / 1000).toFixed(0);
-    const totalSec = ((Date.now() - _pbStartMs)     / 1000).toFixed(0);
-    // Estimate remaining time from progress fraction
-    const frac = (_pbCurrent + 0.5) / _pbSteps.length;
-    const elapsed = (Date.now() - _pbStartMs) / 1000;
-    const etaPart = (frac > 0.05 && elapsed > 2)
-      ? ` · ~${Math.max(0, Math.round(elapsed / frac * (1 - frac)))}s remaining`
-      : '';
-    etaEl.textContent = `step ${stepSec}s · total ${totalSec}s${etaPart}`;
-  }, 1000);
+  _pbTickTimer = setInterval(_pbTick, 1000);
+}
+
+function _pbTick() {
+  if (_pbCurrent < 0) return;
+  const etaEl = document.getElementById('progressEta');
+  if (!etaEl || etaEl.dataset.finalised === '1') return;
+
+  const weights   = _pbSteps === PIPELINE_3 ? STEP_WEIGHTS_3 : STEP_WEIGHTS_4;
+  const stepSec   = Math.round((Date.now() - _pbStepStartMs) / 1000);
+  const totalSec  = Math.round((Date.now() - _pbStartMs) / 1000);
+
+  // Fraction of total work done — use chunk count for step 2 of chunked pipeline.
+  let doneFrac = 0;
+  for (let i = 0; i < _pbCurrent; i++) doneFrac += weights[i];
+  if (_pbSteps === PIPELINE_3 && _pbCurrent === 1 && _pbChunksTotal > 0) {
+    doneFrac += weights[1] * (_pbChunksDone / _pbChunksTotal);
+  } else {
+    const estStepS = weights[_pbCurrent] * _pbTotalEstS;
+    doneFrac += weights[_pbCurrent] * Math.min(0.95, estStepS > 0 ? stepSec / estStepS : 0);
+  }
+
+  const remainS = Math.max(0, Math.round(_pbTotalEstS * (1 - doneFrac)));
+  const etaPart = totalSec > 3
+    ? ` · ~${remainS}s remaining`
+    : '';
+  etaEl.textContent = `step ${stepSec}s · total ${totalSec}s${etaPart}`;
 }
 
 function _advanceStep(idx) {
   if (idx === _pbCurrent) return;
-  const now = Date.now();
-  _pbStepStartMs = now;
-  _pbCurrent = idx;
+  _pbStepStartMs = Date.now();
+  _pbCurrent     = idx;
 
   _pbSteps.forEach((_, i) => {
     const dot = document.getElementById(`pbDot${i}`);
@@ -1511,12 +1581,8 @@ function _advanceStep(idx) {
   const step = _pbSteps[idx];
   if (step) document.getElementById('progressStepName').textContent = step.name;
 
-  // Reset elapsed ticker for this new step
   const etaEl = document.getElementById('progressEta');
-  if (etaEl) {
-    delete etaEl.dataset.finalised;
-    etaEl.textContent = `step 0s · total 0s`;
-  }
+  if (etaEl) { delete etaEl.dataset.finalised; }
 }
 
 function _finishProgressBar() {
@@ -1534,24 +1600,69 @@ function _finishProgressBar() {
 }
 
 function _parseStepFromMessage(msg) {
-  // Detect step markers like [1/4], [2/4], [3/4], [4/4] or [1/3], [2/3], [3/3]
+  // Chunk progress: "Processing N chunks" or "Chunk X/N done"
+  const chunksStartM = msg.match(/Processing (\d+) chunks/);
+  if (chunksStartM) { _pbChunksTotal = parseInt(chunksStartM[1]); _pbChunksDone = 0; }
+  const chunkDoneM = msg.match(/Chunk \d+\/(\d+) (?:done|resumed)/);
+  if (chunkDoneM) { _pbChunksTotal = parseInt(chunkDoneM[1]); _pbChunksDone++; }
+
+  // Step markers: [1/4], [2/3] etc.
   const m = msg.match(/^\[(\d+)\/(\d+)\]/);
   if (!m) return;
-  const step  = parseInt(m[1]);
-  const total = parseInt(m[2]);
+  const step = parseInt(m[1]), total = parseInt(m[2]);
 
   if (total === 4) {
-    // Single-pass 4-step pipeline: [1/4]→0, [2/4]→1, [3/4]→2, [4/4]→3
     if (_pbCurrent === -1) _initProgressBar(PIPELINE_4);
     _advanceStep(step - 1);
   } else if (total === 3) {
-    if (_pbCurrent === -1) {
-      // Chunked pipeline — only initialise 3-step if 4-step hasn't started yet
-      _initProgressBar(PIPELINE_3);
-    }
+    if (_pbCurrent === -1) _initProgressBar(PIPELINE_3);
     if (_pbSteps === PIPELINE_3) _advanceStep(step - 1);
-    // If somehow in 4-step mode, [N/3] is unexpected — ignore
   }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent mid-flight polling — detect when another precompute starts/ends
+// ---------------------------------------------------------------------------
+function _startConcurrentPoll(jobKey) {
+  _pbJobKey      = jobKey;
+  _pbActiveCount = 1;
+  if (_pbPollTimer) clearInterval(_pbPollTimer);
+  _pbPollTimer = setInterval(async () => {
+    try {
+      const r = await fetch(buildUrl('/api/precompute/active'));
+      if (!r.ok) return;
+      const d    = await r.json();
+      const jobs = d.active_jobs || [];
+      const count = jobs.length;
+      if (count === _pbActiveCount) return;
+
+      const others = jobs.filter(j => j.job_key !== _pbJobKey);
+      if (count > _pbActiveCount) {
+        // Someone else started — our effective slots dropped
+        _pbNSlots = Math.max(1, Math.floor(3 / count));
+        _pbTotalEstS = _estimateTotalS(_pbRadius, _pbNSlots);
+        const desc = others.map(j => `${j.radius_m}m`).join(', ');
+        showConcurrentWarning(others);
+        appendProgressLine(
+          `⚠ Another precompute started (${desc}) — your chunks now share resources, expect ~${Math.round(3 / _pbNSlots)}× slower processing`
+        );
+      } else if (count < _pbActiveCount && _pbActiveCount > 1) {
+        // Someone finished — speed restored
+        _pbNSlots = Math.min(3, Math.max(1, Math.floor(3 / Math.max(1, count))));
+        _pbTotalEstS = _estimateTotalS(_pbRadius, _pbNSlots);
+        const warn = document.getElementById('concurrentWarning');
+        warn.classList.remove('visible');
+        warn.textContent = '';
+        appendProgressLine('✓ Other precompute finished — back to full speed');
+      }
+      _pbActiveCount = count;
+    } catch (_) {}
+  }, 12000); // poll every 12s
+}
+
+function _stopConcurrentPoll() {
+  if (_pbPollTimer) { clearInterval(_pbPollTimer); _pbPollTimer = null; }
+  _pbJobKey = null;
 }
 
 function showLoading(text, showProgress) {
@@ -1581,6 +1692,7 @@ function appendProgressLine(msg) {
 
 function hideLoading() {
   if (_pbTickTimer) { clearInterval(_pbTickTimer); _pbTickTimer = null; }
+  _stopConcurrentPoll();
   document.getElementById('loadingOverlay').classList.remove('active');
   const prog = document.getElementById('loadingProgress');
   prog.classList.remove('visible');
@@ -1903,6 +2015,13 @@ async function getBatchPins() {
 // Saves job_key to localStorage so a page refresh can offer to resume.
 // ---------------------------------------------------------------------------
 async function _runPrecomputeStream(lat, lon, radius, tileSource, isResume, concurrentJobs) {
+  // Set ETA state before initialising the progress bar so _initProgressBar
+  // can compute the initial estimate.
+  _pbRadius  = radius;
+  _pbNSlots  = concurrentJobs && concurrentJobs.length > 0
+    ? Math.max(1, Math.floor(3 / (concurrentJobs.length + 1)))
+    : 3;
+
   const verb = isResume ? 'Resuming' : 'Precomputing';
   showLoading(`${verb} ${radius}m radius…`, true);
   if (!isResume) {
@@ -1950,6 +2069,8 @@ async function _runPrecomputeStream(lat, lon, radius, tileSource, isResume, conc
               job_key: data.job_key, lat, lon, radius_m: radius,
               tile_source: tileSource, started_at: Date.now(),
             }));
+            // Start polling for concurrent jobs only once we have a confirmed job key
+            if (!data.reconnected) _startConcurrentPoll(data.job_key);
             if (data.reconnected) {
               appendProgressLine(`↩ Reconnected — replaying ${data.elapsed_s}s of buffered progress…`);
             }

--- a/front-back-garden/index.html
+++ b/front-back-garden/index.html
@@ -491,6 +491,20 @@ body {
 .loading-progress .prog-line { padding: 1px 0; line-height: 1.5; }
 .loading-progress .prog-line.step { color: var(--accent); font-weight: 600; }
 .loading-progress .prog-line.sub { color: var(--text-dim); padding-left: 8px; }
+.loading-progress .prog-line.warn { color: var(--orange); font-weight: 600; }
+.concurrent-warning {
+  display: none;
+  margin-top: 8px;
+  padding: 6px 10px;
+  background: rgba(245,158,11,0.12);
+  border: 1px solid rgba(245,158,11,0.35);
+  border-radius: 6px;
+  color: var(--orange);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+}
+.concurrent-warning.visible { display: block; }
 
 .cache-badge {
   display: inline-flex;
@@ -1071,6 +1085,7 @@ footer a:hover { text-decoration: underline; }
         </div>
       </div>
 
+      <div class="concurrent-warning" id="concurrentWarning"></div>
       <div class="loading-progress" id="loadingProgress"></div>
     </div>
     <div class="results-drawer" id="resultsDrawer">
@@ -1571,7 +1586,19 @@ function hideLoading() {
   prog.classList.remove('visible');
   prog.innerHTML = '';
   document.getElementById('progressBarWrap').classList.remove('visible');
+  const warn = document.getElementById('concurrentWarning');
+  warn.classList.remove('visible');
+  warn.textContent = '';
   _pbCurrent = -1;
+}
+
+function showConcurrentWarning(activeJobs) {
+  const warn = document.getElementById('concurrentWarning');
+  const desc = activeJobs.map(j =>
+    `${j.radius_m}m at ${j.lat?.toFixed(4)}, ${j.lon?.toFixed(4)}`
+  ).join('; ');
+  warn.textContent = `⚠ Another precompute is already running (${desc}) — expect slower processing due to shared resources.`;
+  warn.classList.add('visible');
 }
 
 function showResults(title, html) {
@@ -1875,12 +1902,17 @@ async function getBatchPins() {
 // Precompute — streams SSE progress, then auto-loads pins on completion.
 // Saves job_key to localStorage so a page refresh can offer to resume.
 // ---------------------------------------------------------------------------
-async function _runPrecomputeStream(lat, lon, radius, tileSource, isResume) {
+async function _runPrecomputeStream(lat, lon, radius, tileSource, isResume, concurrentJobs) {
   const verb = isResume ? 'Resuming' : 'Precomputing';
   showLoading(`${verb} ${radius}m radius…`, true);
   if (!isResume) {
     appendProgressLine(`Starting precompute for ${radius}m at ${lat.toFixed(5)}, ${lon.toFixed(5)}…`);
     _initProgressBar(PIPELINE_4); // initialise now; will switch to PIPELINE_3 if needed
+    if (concurrentJobs && concurrentJobs.length > 0) {
+      showConcurrentWarning(concurrentJobs);
+      const desc = concurrentJobs.map(j => `${j.radius_m}m at ${j.lat?.toFixed(4)}, ${j.lon?.toFixed(4)}`).join(', ');
+      appendProgressLine(`⚠ Another precompute is running (${desc}) — processing will be slower`);
+    }
   } else {
     appendProgressLine(`Reconnecting to in-progress precompute…`);
   }
@@ -1963,7 +1995,22 @@ async function precomputeArea() {
   const radius     = parseInt(document.getElementById('batchRadius').value) || 200;
   const tileSource = document.getElementById('batchTileSource').value;
   const [lat, lon] = coords.split(',').map(s => parseFloat(s.trim()));
-  await _runPrecomputeStream(lat, lon, radius, tileSource, false);
+
+  // Check if any other precomputes are already running before kicking off.
+  // We still proceed — this is informational, not a block.
+  let concurrentJobs = [];
+  try {
+    const r = await fetch(buildUrl('/api/precompute/active'));
+    if (r.ok) {
+      const d = await r.json();
+      // Exclude a job at the same lat/lon/radius (i.e. reconnecting to our own)
+      concurrentJobs = (d.active_jobs || []).filter(j =>
+        !(Math.abs(j.lat - lat) < 0.0001 && Math.abs(j.lon - lon) < 0.0001 && j.radius_m === radius)
+      );
+    }
+  } catch (_) {}
+
+  await _runPrecomputeStream(lat, lon, radius, tileSource, false, concurrentJobs);
 }
 
 // ---------------------------------------------------------------------------

--- a/front-back-garden/index.html
+++ b/front-back-garden/index.html
@@ -2061,34 +2061,16 @@ async function checkCacheStatus() {
   if (isNaN(lat) || isNaN(lon)) { badge.style.display = 'none'; return; }
 
   try {
-    // Fire precompute with a read that returns immediately if cached;
-    // abort after 2s so we don't accidentally trigger a long precompute.
-    const ctrl = new AbortController();
-    const timeout = setTimeout(() => ctrl.abort(), 2000);
-
-    const r = await fetch(buildUrl('/api/precompute'), {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ lat, lon, radius_m: radius }),
-      signal:  ctrl.signal,
-    });
-    clearTimeout(timeout);
-
-    // Read first SSE chunk only
-    const reader  = r.body.getReader();
-    const decoder = new TextDecoder();
-    const { value } = await reader.read();
-    reader.cancel();
-
-    const text = decoder.decode(value || new Uint8Array());
-    const cached = text.includes('"from_cache": true') || text.includes('"from_cache":true');
+    const url = buildUrl(`/api/precompute/check?lat=${lat}&lon=${lon}&radius_m=${radius}`);
+    const r = await fetch(url);
+    if (!r.ok) { badge.style.display = 'none'; return; }
+    const { cached } = await r.json();
 
     badge.style.display = 'block';
     badge.innerHTML = cached
       ? `<span class="cache-badge cached">✓ Cached — pins ready</span>`
       : `<span class="cache-badge uncached">○ Not cached — precompute needed</span>`;
   } catch (_) {
-    // Abort or network error — don't show badge
     badge.style.display = 'none';
   }
 }

--- a/front-back-garden/src/precompute.py
+++ b/front-back-garden/src/precompute.py
@@ -21,7 +21,7 @@ import math
 import os
 import pickle
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict
 from pathlib import Path
@@ -102,24 +102,29 @@ BUILDING_CHUNK_THRESHOLD = 2500
 # Cross-process heavy-phase semaphore + RAM admission gate
 # ---------------------------------------------------------------------------
 # Uvicorn runs multiple workers as separate OS processes. A standard
-# threading.Lock() only works within one process. We use an exclusive
-# fcntl file lock on a temp file so that only ONE worker can run the
-# memory-intensive phases (vegetation → classify → pins) at a time.
+# threading.Lock() only works within one process. We use fcntl advisory
+# locks on N separate slot files to implement a cross-process semaphore
+# that allows up to N concurrent holders (across all workers and all
+# chunks in the same worker).
 #
-# Additionally, even after the lock is acquired we re-check available RAM.
-# If the system is still memory-constrained (previous worker's GC hasn't
-# freed yet), we wait here rather than spike into OOM territory. This gives
-# the server a soft 7 GB ceiling: any work that would exceed it is placed
-# on the back burner and runs when memory is available, rather than crashing.
+# The semaphore caps CONCURRENCY of memory-intensive phases. The RAM
+# admission gate (see _wait_for_ram_headroom) caps OVERALL memory usage.
+# Together: at most N chunks running at once, AND never below the free
+# RAM floor — whichever is stricter wins.
 #
-# Step 1 (tile + OSM fetch) is I/O-bound and low-memory — it runs freely
-# in both workers concurrently. Steps 2-4 are the memory-intensive work.
-#
-# The lock is *not* held while writing to cache, so the next worker can
-# start as soon as processing completes and large arrays are freed.
-_HEAVY_LOCK_PATH = "/tmp/garden_heavy_precompute.lock"
+# Why not a single exclusive lock any more? A single lock serialises
+# chunks within one precompute, leaving ~50% of available RAM unused
+# on a lightly-loaded server. N=2–3 lets one request process several
+# chunks in parallel, cutting wall time by ~2-3x.
+_HEAVY_LOCK_DIR = "/tmp/garden_heavy_precompute.d"
 
-# How much free RAM we require before and after acquiring the lock.
+# Maximum number of memory-intensive phases that can run concurrently
+# across all workers and threads. Peak per-chunk spike is ~1-2 GB;
+# 3 slots × 2 GB = 6 GB worst case, fits comfortably under the 7 GB cap.
+# Override via GARDEN_HEAVY_SLOTS env var for tuning.
+_HEAVY_SLOTS: int = int(os.environ.get("GARDEN_HEAVY_SLOTS", "3"))
+
+# How much free RAM we require before acquiring a slot.
 # On an 8 GB server: requiring 1.0 GB free ≈ a 7.0 GB effective ceiling.
 # The single-pass pipeline peaks at ~2 GB (image-size-driven, not building-count).
 # OS + idle worker use ~0.5–1 GB, so total at peak is ~3–4 GB — well under 7 GB.
@@ -130,6 +135,17 @@ _MIN_FREE_RAM_GB: float = 1.0
 
 # How often to re-check RAM while waiting (seconds).
 _RAM_POLL_INTERVAL_S: float = 5.0
+
+# How often the semaphore polls for a free slot when all N are taken.
+_SEM_POLL_INTERVAL_S: float = 1.0
+
+
+def _ensure_lock_dir() -> None:
+    """Create the /tmp/garden_heavy_precompute.d directory if missing."""
+    try:
+        os.makedirs(_HEAVY_LOCK_DIR, exist_ok=True)
+    except Exception:
+        pass
 
 
 def _wait_for_ram_headroom(log_fn: Callable[[str], None] | None = None) -> None:
@@ -164,49 +180,146 @@ def _wait_for_ram_headroom(log_fn: Callable[[str], None] | None = None) -> None:
         time.sleep(_RAM_POLL_INTERVAL_S)
 
 
+def _try_acquire_slot() -> Optional[Tuple[Any, int]]:
+    """
+    Try to acquire any one of the N semaphore slots non-blockingly.
+
+    Returns (fd, slot_index) on success, or None if all slots are taken.
+    The caller owns the fd and MUST close it to release the slot.
+    """
+    _ensure_lock_dir()
+    for slot in range(_HEAVY_SLOTS):
+        path = os.path.join(_HEAVY_LOCK_DIR, f"slot_{slot}.lock")
+        fd = open(path, "w")
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd, slot
+        except BlockingIOError:
+            fd.close()
+            continue
+        except Exception:
+            fd.close()
+            continue
+    return None
+
+
 @contextmanager
 def _heavy_phase_lock(log_fn: Callable[[str], None] | None = None):
     """
-    Exclusive cross-process lock for memory-intensive precompute phases.
+    Counting semaphore for memory-intensive precompute phases.
 
     Combines two guards:
-    1. fcntl exclusive file lock — only ONE worker processes at a time.
-    2. RAM admission check — waits until _MIN_FREE_RAM_GB is available,
-       both before and after acquiring the lock.
+    1. fcntl semaphore over N slot files — at most _HEAVY_SLOTS chunks
+       run the heavy phase concurrently (across ALL workers and threads).
+    2. RAM admission check — waits until _MIN_FREE_RAM_GB is available
+       both before acquiring a slot and again after acquiring it.
 
-    The double RAM check matters: the worker that just released the lock
-    may not have had its GC run yet, so RAM could still be high when the
-    next worker acquires. Checking again inside ensures we only start heavy
-    work when memory has actually been freed.
+    The double RAM check matters: another holder may not have had its GC
+    run yet, so RAM could still be high when we acquire a slot. Checking
+    again ensures we only start heavy work when memory has actually freed.
+
+    If all slots are full we poll every _SEM_POLL_INTERVAL_S for a free slot.
     """
-    # Guard 1: don't even compete for the lock if RAM is critically low.
     _wait_for_ram_headroom(log_fn)
 
     if log_fn:
-        log_fn("    [mem-guard] Waiting for memory slot...")
+        log_fn(
+            f"    [mem-guard] Waiting for memory slot "
+            f"(up to {_HEAVY_SLOTS} concurrent)..."
+        )
     t_wait = time.time()
-    fd = open(_HEAVY_LOCK_PATH, "w")
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
+    acquired: Optional[Tuple[Any, int]] = None
+    while acquired is None:
+        acquired = _try_acquire_slot()
+        if acquired is None:
+            time.sleep(_SEM_POLL_INTERVAL_S)
+            _wait_for_ram_headroom(log_fn)
 
-        # Guard 2: re-check RAM now that we hold the lock. The previous
-        # worker's large arrays may still be in memory if its GC is delayed.
+    fd, slot = acquired
+    try:
         _wait_for_ram_headroom(log_fn)
 
         waited = time.time() - t_wait
         if log_fn and waited > 0.5:
             log_fn(
-                f"    [mem-guard] Memory slot acquired after {waited:.1f}s "
+                f"    [mem-guard] Slot {slot} acquired after {waited:.1f}s "
                 f"[RAM: {_ram_str()}]"
             )
         elif log_fn:
-            log_fn(f"    [mem-guard] Memory slot acquired [RAM: {_ram_str()}]")
+            log_fn(
+                f"    [mem-guard] Slot {slot} acquired "
+                f"[RAM: {_ram_str()}]"
+            )
         yield
     finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        fd.close()
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            fd.close()
         if log_fn:
-            log_fn(f"    [mem-guard] Memory slot released [RAM: {_ram_str()}]")
+            log_fn(
+                f"    [mem-guard] Slot {slot} released "
+                f"[RAM: {_ram_str()}]"
+            )
+
+
+class _PeakRamSampler:
+    """
+    Background thread that samples process RAM usage at a fixed interval.
+
+    Records the maximum RSS seen between `start()` and `stop()`. Useful for
+    measuring the true peak of a short-lived heavy phase (e.g. one chunk).
+
+    Fallback-safe: if psutil is unavailable, peak_mb is None.
+    """
+
+    def __init__(self, interval_s: float = 0.25) -> None:
+        self._interval = interval_s
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.peak_rss_mb: Optional[float] = None
+        self.start_rss_mb: Optional[float] = None
+
+    def _run(self) -> None:
+        if not _PSUTIL_AVAILABLE:
+            return
+        try:
+            proc = _psutil.Process(os.getpid())
+            peak = proc.memory_info().rss
+            self.start_rss_mb = peak / (1024 ** 2)
+            while not self._stop.is_set():
+                try:
+                    rss = proc.memory_info().rss
+                    if rss > peak:
+                        peak = rss
+                except Exception:
+                    break
+                self._stop.wait(self._interval)
+            self.peak_rss_mb = peak / (1024 ** 2)
+        except Exception:
+            return
+
+    def __enter__(self) -> "_PeakRamSampler":
+        if _PSUTIL_AVAILABLE:
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+
+    def summary(self) -> str:
+        if self.peak_rss_mb is None:
+            return "peak RSS: n/a"
+        if self.start_rss_mb is None:
+            return f"peak RSS: {self.peak_rss_mb:.0f} MB"
+        delta = self.peak_rss_mb - self.start_rss_mb
+        return (
+            f"peak RSS: {self.peak_rss_mb:.0f} MB "
+            f"(Δ+{delta:.0f} MB from start)"
+        )
 
 
 @dataclass
@@ -1706,44 +1819,70 @@ class PrecomputeManager:
 
         chunks = self._generate_chunk_grid(center_lat, center_lon, radius_m)
         n_chunks = len(chunks)
-        _log(f"[2/3] Processing {n_chunks} chunks "
-             f"({CHUNK_SIZE_M}m grid, {CHUNK_OVERLAP_M}m overlap)...")
 
-        all_pins: List[DeliveryPin] = []
+        # Chunks run concurrently up to the semaphore cap. Each thread does
+        # its own cache check / crop / OSM filter / heavy phase / persist.
+        # The semaphore inside _heavy_phase_lock caps concurrent heavy phases;
+        # the ThreadPoolExecutor's max_workers matches so we don't spin up
+        # threads that will just sit on the semaphore.
+        chunk_workers = max(1, _HEAVY_SLOTS)
+        _log(
+            f"[2/3] Processing {n_chunks} chunks "
+            f"({CHUNK_SIZE_M}m grid, {CHUNK_OVERLAP_M}m overlap, "
+            f"up to {chunk_workers} concurrent)..."
+        )
 
-        for ci, chunk in enumerate(chunks):
+        # Serialise log output so concurrent chunk threads don't interleave.
+        _log_lock = threading.Lock()
+
+        def _tlog(msg: str) -> None:
+            with _log_lock:
+                _log(msg)
+
+        def _process_one_chunk(ci: int, chunk: Dict[str, Any]) -> List[DeliveryPin]:
             chunk_cache_path = cache_path.parent / f"{cache_path.stem}_chunk{ci}.pkl"
 
-            # Resume from partial cache if available.
             if chunk_cache_path.exists():
                 try:
                     with open(chunk_cache_path, "rb") as f:
                         saved_pins = pickle.load(f)
-                    _log(f"    Chunk {ci + 1}/{n_chunks}... resumed from partial cache "
-                         f"({len(saved_pins)} pins)")
-                    all_pins.extend(saved_pins)
-                    continue
+                    _tlog(
+                        f"    Chunk {ci + 1}/{n_chunks} resumed from partial cache "
+                        f"({len(saved_pins)} pins)"
+                    )
+                    return saved_pins
                 except Exception:
                     chunk_cache_path.unlink(missing_ok=True)
 
-            _log(f"    Chunk {ci + 1}/{n_chunks}... [RAM: {_ram_str()}]")
+            _tlog(
+                f"    Chunk {ci + 1}/{n_chunks} starting... [RAM: {_ram_str()}]"
+            )
+            t_chunk = time.time()
 
             image, metadata = _crop_chunk_image(chunk)
             if image is None:
-                continue
+                return []
 
-            # Filter OSM data to chunk full bounds.
             fb = chunk["full_bounds"]
             cb = chunk["core_bounds"]
             c_buildings = buildings[buildings.intersects(fb)].copy()
             c_roads = roads[roads.intersects(fb)].copy()
-            c_driveways = driveways[driveways.intersects(fb)].copy() if not driveways.empty else driveways
+            c_driveways = (
+                driveways[driveways.intersects(fb)].copy()
+                if not driveways.empty else driveways
+            )
             _empty = gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
-            c_addr = address_polygons[address_polygons.intersects(fb)].copy() if not address_polygons.empty else _empty
-            c_prop = property_boundaries[property_boundaries.intersects(fb)].copy() if not property_boundaries.empty else _empty
+            c_addr = (
+                address_polygons[address_polygons.intersects(fb)].copy()
+                if not address_polygons.empty else _empty
+            )
+            c_prop = (
+                property_boundaries[property_boundaries.intersects(fb)].copy()
+                if not property_boundaries.empty else _empty
+            )
 
             if c_buildings.empty:
-                continue
+                return []
 
             c_buildings = c_buildings.reset_index(drop=True)
             c_roads = c_roads.reset_index(drop=True)
@@ -1754,25 +1893,50 @@ class PrecomputeManager:
             geo_bounds = metadata["geo_bounds"]
             image_size = tuple(metadata["image_size"])
 
-            # Acquire the cross-process lock for this chunk's heavy phases.
-            # Image data is already cropped (cheap); only vegetation→classify→pins
-            # is memory-intensive. Holding the lock per-chunk (not per-full-precompute)
-            # lets the other worker process its own chunks between ours.
-            with _heavy_phase_lock(_log):
+            # Acquire a semaphore slot for this chunk's heavy phases.
+            # Up to _HEAVY_SLOTS chunks run concurrently across all workers
+            # and all chunks; the RAM admission gate enforces the absolute
+            # ceiling if slots alone aren't restrictive enough.
+            with _heavy_phase_lock(_tlog), _PeakRamSampler() as sampler:
                 chunk_pins = self._process_chunk_pins(
                     image, geo_bounds, image_size,
                     c_buildings, c_roads, c_driveways, c_addr, c_prop,
                     center_lat, center_lon, cb,
                 )
 
-            # Persist chunk pins so an interrupted run can resume here.
+            elapsed = time.time() - t_chunk
+            _tlog(
+                f"    Chunk {ci + 1}/{n_chunks} done in {elapsed:.1f}s "
+                f"({len(chunk_pins)} pins, {sampler.summary()})"
+            )
+
             try:
                 with open(chunk_cache_path, "wb") as f:
                     pickle.dump(chunk_pins, f)
             except Exception:
                 pass
 
-            all_pins.extend(chunk_pins)
+            return chunk_pins
+
+        all_pins: List[DeliveryPin] = []
+        with ThreadPoolExecutor(
+            max_workers=chunk_workers,
+            thread_name_prefix="chunk",
+        ) as executor:
+            futures = {
+                executor.submit(_process_one_chunk, ci, chunk): ci
+                for ci, chunk in enumerate(chunks)
+            }
+            for future in as_completed(futures):
+                ci = futures[future]
+                try:
+                    chunk_pins = future.result()
+                    all_pins.extend(chunk_pins)
+                except Exception as e:
+                    _log(
+                        f"    Chunk {ci + 1}/{n_chunks} failed: "
+                        f"{type(e).__name__}: {e}"
+                    )
 
         # Release the full image now that all chunks are cropped — it can be
         # ~880 MB for a 3 km radius and is no longer needed.


### PR DESCRIPTION
fixes MNA-4393

## Summary

**perf: parallel chunk processing with counting semaphore + RAM gate**
Replaces the single exclusive `fcntl` lock with a counting semaphore over N slot files (default `N=3`, tunable via `GARDEN_HEAVY_SLOTS`). Chunk processing now runs through a `ThreadPoolExecutor(max_workers=N)`, so up to 3 chunks process concurrently within a single precompute request. The RAM admission gate (`_MIN_FREE_RAM_GB = 1.0`) remains in place as an absolute ceiling. A `_PeakRamSampler` background thread records peak RSS per chunk so true memory footprint is visible in logs. Result on the 1000m Ringsend test (1,494 buildings, 16 chunks): **117s vs ~15 minutes previously**, with peak system RAM ~6.5–7 GB.

**fix: accidental precompute triggered on every map click**
`checkCacheStatus()` was POSTing to `/api/precompute` just to check whether an area was cached. If uncached the server immediately started a real background job; the client's 2-second `AbortController` only cancelled the stream read, not the server-side work. This caused unsolicited precomputes (e.g. a 200m job) to grab the memory semaphore and delay the user's real request by minutes. Fix: new `GET /api/precompute/check?lat=&lon=&radius_m=` endpoint calls `is_area_cached()` with zero side-effects. A precompute now only fires when the user explicitly clicks the button.

**feat: concurrent precompute warning at job start**
Before firing a precompute, the frontend checks `/api/precompute/active`. If other jobs are running, a persistent orange banner and a log line both appear immediately, naming the competing job(s). Cleared automatically when the job finishes.

**feat: accurate ETA + mid-flight concurrent speed warning**
Replaces the old linear-fraction ETA guess with a step-weighted model calibrated to real server measurements (200m≈150s, 1000m≈230s, 1500m≈440s with 3 concurrent slots, log-linear interpolation between). The chunk step uses exact `Chunk X/N done` message counts for precise within-step progress. Once the job key is confirmed, a poll runs every 12 seconds: if a second precompute starts mid-flight the orange banner updates, a log line shows the slowdown multiplier, and the ETA recalculates for the reduced slot count; when they finish the banner dismisses and ETA restores to full speed.
