### PR TITLE
chore(github): add Notion task verification for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,16 @@
-## Description
+## Notion Task
 
-Please include a summary of the change, which issues/bugs are addressed and add motivation/context for the change.
+refs MNA-####
 
-## Linked Issue
+<!-- Replace #### with your task number. The keyword must be one of: fixes, closes, or refs (not "ref" alone).
 
-fixes # (issue)
+Examples that pass CI:
 
-_Use the following [guide](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to see how to link an issue_
+  fixes MNA-xxxx
+  closes MNA-xxxx
+  refs MNA-xxxx
 
-## Dev checklist
-
-- [ ] Tests performed in simulation environment
-- [ ] Tests performed on hardware (where applicable) 
-
-## Reviewer checklist
-
-- [ ] Style guide adherence checked
-
-## Additional context
-
-Add any other context or screenshots about the feature request here.
+The CI check will verify the task exists in Notion and is not in a
+blocked status (Done, Completed). PRs without a valid reference will
+fail the "Verify Notion Task" check.
+-->

--- a/.github/scripts/verify-notion-task.mjs
+++ b/.github/scripts/verify-notion-task.mjs
@@ -1,0 +1,138 @@
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import { Client } from "@notionhq/client";
+
+function extractTaskId(text) {
+  if (!text) return null;
+  const regex = /(fixes|closes|refs)\s+(MNA-\d+)/i;
+  const match = text.match(regex);
+  return match ? match[2].toUpperCase() : null;
+}
+
+function getStatusName(page, statusPropertyName) {
+  const prop = page?.properties?.[statusPropertyName];
+  if (!prop) return null;
+  if (prop.type === "status") return prop.status?.name ?? null;
+  if (prop.type === "select") return prop.select?.name ?? null;
+  return null;
+}
+
+function listPageProperties(page) {
+  return Object.entries(page?.properties ?? {})
+    .map(([name, p]) => `  • "${name}" (${p.type})`)
+    .join("\n");
+}
+
+function resolveDataSourceId(db) {
+  const sources = db?.data_sources;
+  if (!Array.isArray(sources) || sources.length === 0) return null;
+  return sources[0].id;
+}
+
+async function fetchSamplePage(notion, db, databaseId) {
+  const dataSourceId = resolveDataSourceId(db);
+  if (dataSourceId && notion.dataSources?.query) {
+    const res = await notion.dataSources.query({ data_source_id: dataSourceId, page_size: 1 });
+    return res?.results?.[0] ?? null;
+  }
+  if (notion.databases?.query) {
+    const res = await notion.databases.query({ database_id: databaseId, page_size: 1 });
+    return res?.results?.[0] ?? null;
+  }
+  return null;
+}
+
+function detectFilterType(samplePage, propertyName) {
+  const prop = samplePage?.properties?.[propertyName];
+  if (!prop) return null;
+  if (prop.type === "title") return "title";
+  if (prop.type === "unique_id") return "unique_id";
+  return "rich_text";
+}
+
+async function queryFiltered(notion, db, databaseId, taskIdProperty, filterType, taskId) {
+  const filter =
+    filterType === "unique_id"
+      ? { property: taskIdProperty, unique_id: { equals: parseInt(taskId.replace(/\D/g, ""), 10) } }
+      : { property: taskIdProperty, [filterType]: { equals: taskId } };
+
+  const dataSourceId = resolveDataSourceId(db);
+  if (dataSourceId && notion.dataSources?.query) {
+    return notion.dataSources.query({ data_source_id: dataSourceId, filter, page_size: 1 });
+  }
+  if (notion.databases?.query) {
+    return notion.databases.query({ database_id: databaseId, filter, page_size: 1 });
+  }
+  core.setFailed("❌ Unsupported Notion SDK: neither dataSources.query nor databases.query is available.");
+  return null;
+}
+
+async function run() {
+  try {
+    const notionToken = process.env.NOTION_TOKEN;
+    const databaseId = process.env.NOTION_DATABASE_ID;
+
+    const taskIdProperty = process.env.NOTION_TASK_ID_PROPERTY || "ID";
+    const statusProperty = process.env.NOTION_STATUS_PROPERTY || "Status";
+    const blockedStatuses = (process.env.NOTION_BLOCKED_STATUSES || "Done,Completed")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (!notionToken) return core.setFailed("Missing NOTION_TOKEN secret.");
+    if (!databaseId) return core.setFailed("Missing NOTION_DATABASE_ID secret.");
+
+    const pr = github.context.payload.pull_request;
+    if (!pr) return core.setFailed("This action must run on pull_request events.");
+
+    const taskId = extractTaskId(pr.body || "");
+    if (!taskId) {
+      return core.setFailed("❌ PR must include a task reference like: fixes MNA-1234");
+    }
+
+    const notion = new Client({ auth: notionToken });
+    const db = await notion.databases.retrieve({ database_id: databaseId });
+
+    const sample = await fetchSamplePage(notion, db, databaseId);
+    if (!sample) {
+      return core.setFailed("❌ Database appears empty — cannot discover properties.");
+    }
+
+    const availableProps = listPageProperties(sample);
+    const sampleProps = sample.properties ?? {};
+
+    if (!sampleProps[taskIdProperty]) {
+      return core.setFailed(
+        `❌ Property "${taskIdProperty}" (NOTION_TASK_ID_PROPERTY) not found.\nAvailable properties:\n${availableProps}`
+      );
+    }
+    if (!sampleProps[statusProperty]) {
+      core.warning(
+        `Property "${statusProperty}" (NOTION_STATUS_PROPERTY) not found — status check will be skipped.\nAvailable properties:\n${availableProps}`
+      );
+    }
+
+    const filterType = detectFilterType(sample, taskIdProperty);
+    core.info(`Querying "${taskIdProperty}" (${filterType}) = "${taskId}"`);
+
+    const response = await queryFiltered(notion, db, databaseId, taskIdProperty, filterType, taskId);
+    if (!response) return;
+
+    if (!response.results || response.results.length === 0) {
+      return core.setFailed(`❌ No Notion task found with ${taskIdProperty} = ${taskId}`);
+    }
+
+    const page = response.results[0];
+    const status = getStatusName(page, statusProperty);
+
+    if (status && blockedStatuses.includes(status)) {
+      return core.setFailed(`❌ Task ${taskId} is "${status}" (blocked). Link an active task.`);
+    }
+
+    core.notice(`✅ Valid Notion task found: ${taskId}${status ? ` | Status: ${status}` : ""}`);
+  } catch (err) {
+    core.setFailed(err instanceof Error ? err.message : String(err));
+  }
+}
+
+run();

--- a/.github/workflows/verify-notion-task.yml
+++ b/.github/workflows/verify-notion-task.yml
@@ -1,0 +1,31 @@
+name: Verify Notion Task
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  verify-notion-task:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: |
+          echo '{}' > package.json
+          npm i @actions/core @actions/github @notionhq/client
+
+      - name: Validate MNA Task
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+          NOTION_STATUS_PROPERTY: Status
+          NOTION_BLOCKED_STATUSES: Done,Completed
+        run: node .github/scripts/verify-notion-task.mjs


### PR DESCRIPTION
fixes MNA-3486

## Summary
- add `.github/workflows/verify-notion-task.yml` and `.github/scripts/verify-notion-task.mjs` from `software-repo-template`
- align `.github/pull_request_template.md` with the MNA task reference format enforced in CI

## Test plan
- [x] Confirm PR template documents `fixes|closes|refs MNA-<number>`
- [x] Confirm verify workflow triggers on pull requests

Made with [Cursor](https://cursor.com)